### PR TITLE
fix: sprint

### DIFF
--- a/SubmersedVR/Settings.cs
+++ b/SubmersedVR/Settings.cs
@@ -28,6 +28,9 @@ namespace SubmersedVR
         public static float SnowBikeSnapTurningAngle = 45.0f;
         public static event FloatChanged SnowBikeSnapTurningAngleChanged;
 
+        //The game's default ForwardSprintModifier is 2.0f (PlayerMotor.forwardSprintModifier), but this feels slow in VR
+        public static float ForwardSprintModifier = 2.25f;
+
         public static bool IsDebugEnabled;
         public static event BooleanChanged IsDebugChanged;
        
@@ -249,6 +252,13 @@ namespace SubmersedVR
                     SnowBikeSnapTurningAngleChanged(value);
                 }
             });
+
+            panel.AddSliderOption(tab, "Sprint Velocity Multiplier", ForwardSprintModifier, 2f, 3f, ForwardSprintModifier, 0.25f, (value) =>
+            {
+                ForwardSprintModifier = value;
+                //If the player is currently in-game, immediately apply the new value to PlayerMotor to update sprint speed in real time
+                Sprint.OnForwardSprintModifierChanged();
+            }, SliderLabelMode.Float, "0.00");
 
             panel.AddHeading(tab, "Immersion");
             panel.AddToggleOption(tab, "Articulated Hands", ArticulatedHands, (value) => { ArticulatedHands = value;  }, "Hands animate based on the movement of your physical hands.");

--- a/SubmersedVR/SubmersedVR.csproj
+++ b/SubmersedVR/SubmersedVR.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net472</TargetFramework>
     <AssemblyName>SubmersedVR</AssemblyName>
     <Description>A VR Conversion Mod for Subnautica</Description>
-    <Version>0.8.0</Version>
+    <Version>0.8.1</Version>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>
     <!-- NOTE: Change this to your own directoy when building -->

--- a/SubmersedVR/Tweaks/Sprint.cs
+++ b/SubmersedVR/Tweaks/Sprint.cs
@@ -1,0 +1,25 @@
+using HarmonyLib;
+using UnityEngine;
+
+namespace SubmersedVR
+{
+    static class Sprint
+    {
+        public static void OnForwardSprintModifierChanged()
+        {
+            foreach (var playerMotor in Object.FindObjectsOfType<PlayerMotor>())
+            {
+                playerMotor.forwardSprintModifier = Settings.ForwardSprintModifier;
+            }
+        }
+
+        [HarmonyPatch(typeof(PlayerMotor), "Start")]
+        public static class PlayerMotor_ForwardSprintModifier
+        {
+            static void Postfix(PlayerMotor __instance)
+            {
+                __instance.forwardSprintModifier = Settings.ForwardSprintModifier;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Hello, and thanks for the amazing work on this mod!

While playing today, I noticed that walking on the islands felt slower than it should be.

Searching about it, I found a few related issues on GitHub:
* https://github.com/jbusfield/SubmersedVR_BZ/issues/3
* https://github.com/Okabintaro/SubmersedVR/issues/170
* https://github.com/Okabintaro/SubmersedVR/issues/116
* https://github.com/Okabintaro/SubmersedVR/issues/59
* https://github.com/Okabintaro/SubmersedVR/issues/10

Debugging the code, I confirmed that Subnautica does register the sprint input, but the movement speed is slow.

To address this, I adjusted the `forwardSprintModifier` value from `2` to `2.25`. This tweak fixed the issue for me, but it may not feel right for everyone. To make it more flexible, I added a slider in the SubmersedVR settings menu so players can adjust this modifier in-game (options: 2, 2.25, 2.5, 2.75, 3).

<img width="710" height="63" alt="image" src="https://github.com/user-attachments/assets/c2ef205a-9a10-484a-9e81-0f531979e894" />